### PR TITLE
#1157 Adding a Summernote Styles css file so that Summernote is usabl…

### DIFF
--- a/src/cloudscribe.Web.StaticFiles/cloudscribe.Web.StaticFiles.csproj
+++ b/src/cloudscribe.Web.StaticFiles/cloudscribe.Web.StaticFiles.csproj
@@ -198,6 +198,7 @@
     <EmbeddedResource Include="css\plyr.css" />
     <EmbeddedResource Include="css\simplemde.min.css" />
 	<EmbeddedResource Include="css\summernote-bs5.min.css" />
+	<EmbeddedResource Include="css\summernote-styles.css" />
 	<EmbeddedResource Include="css\font\summernote.woff2" />
 	<EmbeddedResource Include="css\font\summernote.woff" />
 	<EmbeddedResource Include="css\font\summernote.ttf" />

--- a/src/cloudscribe.Web.StaticFiles/css/summernote-styles.css
+++ b/src/cloudscribe.Web.StaticFiles/css/summernote-styles.css
@@ -1,0 +1,7 @@
+.note-editor.note-frame.card {
+    background-color: #fff;
+}
+
+.note-btn.btn.btn-outline-secondary.btn-sm {
+    color: #6c757d;
+}


### PR DESCRIPTION
…e for any theme chosen.

Users would need to add:
`<link rel="stylesheet" href="@Url.Content("~/cr/css/summernote-styles.css")" asp-append-version="true" />`

to the _Layout of their chosen theme.