### PR TITLE
Version Update: 10.0.0 → 10.1.0

### DIFF
--- a/src/cloudscribe.Common.Gdpr/cloudscribe.Common.Gdpr.csproj
+++ b/src/cloudscribe.Common.Gdpr/cloudscribe.Common.Gdpr.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Attributes and helpers that can be used as tools to help meet GDPR requirements</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <Authors>Joe Audette</Authors>
     <TargetFramework>net10.0</TargetFramework>
     <PackageTags>cloudscribe;gdpr</PackageTags>

--- a/src/cloudscribe.Core.CompiledViews.Bootstrap5/cloudscribe.Core.CompiledViews.Bootstrap5.csproj
+++ b/src/cloudscribe.Core.CompiledViews.Bootstrap5/cloudscribe.Core.CompiledViews.Bootstrap5.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Bootstrap 5 pre-compiled views for cloudscribe.Core.Web</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <Authors>Joe Audette</Authors>

--- a/src/cloudscribe.Core.Identity/cloudscribe.Core.Identity.csproj
+++ b/src/cloudscribe.Core.Identity/cloudscribe.Core.Identity.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>asp.net identity implementation for cloudscribe web application foundation</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <Authors>Joe Audette</Authors>
     <TargetFramework>net10.0</TargetFramework>
     <PackageTags>cloudscribe;identity</PackageTags>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.1.0" />
     <PackageReference Include="IdentityModel" Version="4.0.0" />
     
 

--- a/src/cloudscribe.Core.IdentityServer.EFCore.Common/cloudscribe.Core.IdentityServer.EFCore.Common.csproj
+++ b/src/cloudscribe.Core.IdentityServer.EFCore.Common/cloudscribe.Core.IdentityServer.EFCore.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Entity Framework configuration and operational stores for IdentityServer4 cloudscribe multi-tenant identity integration</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <Authors>Joe Audette</Authors>
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>cloudscribe.Core.IdentityServer.EFCore.Common</AssemblyName>
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.1.0" />
 
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />

--- a/src/cloudscribe.Core.IdentityServer.EFCore.MSSQL/cloudscribe.Core.IdentityServer.EFCore.MSSQL.csproj
+++ b/src/cloudscribe.Core.IdentityServer.EFCore.MSSQL/cloudscribe.Core.IdentityServer.EFCore.MSSQL.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft Sql Server Entity Framework configuration and operational stores for IdentityServer4 cloudscribe multi-tenant identity integration</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <AssemblyName>cloudscribe.Core.IdentityServer.EFCore.MSSQL</AssemblyName>

--- a/src/cloudscribe.Core.IdentityServer.EFCore.MySql/cloudscribe.Core.IdentityServer.EFCore.MySql.csproj
+++ b/src/cloudscribe.Core.IdentityServer.EFCore.MySql/cloudscribe.Core.IdentityServer.EFCore.MySql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>MySql Entity Framework configuration and operational stores for IdentityServer4 cloudscribe multi-tenant identity integration</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;identity</PackageTags>

--- a/src/cloudscribe.Core.IdentityServer.EFCore.PostgreSql/cloudscribe.Core.IdentityServer.EFCore.PostgreSql.csproj
+++ b/src/cloudscribe.Core.IdentityServer.EFCore.PostgreSql/cloudscribe.Core.IdentityServer.EFCore.PostgreSql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>PostgreSql (pgsql) Entity Framework configuration and operational stores for IdentityServer4 cloudscribe multi-tenant identity integration</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;identity</PackageTags>

--- a/src/cloudscribe.Core.IdentityServer.EFCore.SQLite/cloudscribe.Core.IdentityServer.EFCore.SQLite.csproj
+++ b/src/cloudscribe.Core.IdentityServer.EFCore.SQLite/cloudscribe.Core.IdentityServer.EFCore.SQLite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>SQLite Entity Framework configuration and operational stores for IdentityServer4 cloudscribe multi-tenant identity integration</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;identity</PackageTags>

--- a/src/cloudscribe.Core.IdentityServer.NoDb/cloudscribe.Core.IdentityServer.NoDb.csproj
+++ b/src/cloudscribe.Core.IdentityServer.NoDb/cloudscribe.Core.IdentityServer.NoDb.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>NoDb configuration and operational stores for IdentityServer4 cloudscribe multi-tenant identity integration</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;identity</PackageTags>

--- a/src/cloudscribe.Core.IdentityServerIntegration/cloudscribe.Core.IdentityServerIntegration.csproj
+++ b/src/cloudscribe.Core.IdentityServerIntegration/cloudscribe.Core.IdentityServerIntegration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>cloudscribe multi-tenant identity integration for IdentityServer4</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;identity</PackageTags>
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Web.Pagination" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Web.Pagination" Version="10.1.0" />
 
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />

--- a/src/cloudscribe.Core.Ldap.Windows/cloudscribe.Core.Ldap.Windows.csproj
+++ b/src/cloudscribe.Core.Ldap.Windows/cloudscribe.Core.Ldap.Windows.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ILdapHelper implementation for cloudscribe Core LDAP authentication support using windows compatibility shim</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <Authors>Joe Audette, Simon Annetts Idox Software</Authors>
     <TargetFramework>net10.0</TargetFramework>
     <PackageTags>cloudscribe;LDAP;Active Directory</PackageTags>

--- a/src/cloudscribe.Core.Ldap/cloudscribe.Core.Ldap.csproj
+++ b/src/cloudscribe.Core.Ldap/cloudscribe.Core.Ldap.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>ILdapHelper implementation for cloudscribe Core LDAP authentication support</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette, Simon Annetts Idox Software</Authors>
     <PackageTags>cloudscribe;LDAP;Active Directory</PackageTags>

--- a/src/cloudscribe.Core.Models/cloudscribe.Core.Models.csproj
+++ b/src/cloudscribe.Core.Models/cloudscribe.Core.Models.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>model classes for cloudscribe core. you should not normally install this separately, it will be installed if you install cloudscribe.Core.Web</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;models</PackageTags>
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
 

--- a/src/cloudscribe.Core.Storage.EFCore.Common/cloudscribe.Core.Storage.EFCore.Common.csproj
+++ b/src/cloudscribe.Core.Storage.EFCore.Common/cloudscribe.Core.Storage.EFCore.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Entity Framework Core implementation of cloudscribe core commands and queries - typically you do not use this directly, use cloudscribe.Core.Storage.EFCore.MSSQL</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;commands;queries;ef</PackageTags>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.1.0" />
     
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />

--- a/src/cloudscribe.Core.Storage.EFCore.MSSQL/cloudscribe.Core.Storage.EFCore.MSSQL.csproj
+++ b/src/cloudscribe.Core.Storage.EFCore.MSSQL/cloudscribe.Core.Storage.EFCore.MSSQL.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft Sql Server Entity Framework Core implementation of cloudscribe core storage</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;commands;queries;ef</PackageTags>

--- a/src/cloudscribe.Core.Storage.EFCore.MySql/cloudscribe.Core.Storage.EFCore.MySql.csproj
+++ b/src/cloudscribe.Core.Storage.EFCore.MySql/cloudscribe.Core.Storage.EFCore.MySql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>MySql Entity Framework Core implementation of cloudscribe core storage</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;commands;queries;ef</PackageTags>

--- a/src/cloudscribe.Core.Storage.EFCore.PostgreSql/cloudscribe.Core.Storage.EFCore.PostgreSql.csproj
+++ b/src/cloudscribe.Core.Storage.EFCore.PostgreSql/cloudscribe.Core.Storage.EFCore.PostgreSql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>PostgreSql Entity Framework Core implementation of cloudscribe core storage using snake case tables and fields</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;commands;queries;ef</PackageTags>

--- a/src/cloudscribe.Core.Storage.EFCore.SQLite/cloudscribe.Core.Storage.EFCore.SQLite.csproj
+++ b/src/cloudscribe.Core.Storage.EFCore.SQLite/cloudscribe.Core.Storage.EFCore.SQLite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>SQLite Entity Framework Core implementation of cloudscribe core storage</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;commands;queries;ef</PackageTags>

--- a/src/cloudscribe.Core.Storage.NoDb/cloudscribe.Core.Storage.NoDb.csproj
+++ b/src/cloudscribe.Core.Storage.NoDb/cloudscribe.Core.Storage.NoDb.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>NoDb implementation of cloudscribe core commands and queries</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;commands;queries;NoDb</PackageTags>
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Pagination.Models" Version="10.1.0" />
     
     <!-- Upgraded from 1.2.1 to 1.2.2 at net10 upgrade - jk -->
     <PackageReference Include="NoDb" Version="1.2.2" />

--- a/src/cloudscribe.Core.Web/cloudscribe.Core.Web.csproj
+++ b/src/cloudscribe.Core.Web/cloudscribe.Core.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Multi-tenant web application foundation with management for sites, users, roles, claims, and geographic data.</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;multi-tenant;asp.net core;site management</PackageTags>
@@ -40,8 +40,8 @@
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="IPAddressRange" Version="6.2.0" />
-    <PackageReference Include="cloudscribe.Web.Pagination" Version="10.0.0" />
-    <PackageReference Include="cloudscribe.Web.SiteMap.FromNavigation" Version="10.0.0" />
+    <PackageReference Include="cloudscribe.Web.Pagination" Version="10.1.0" />
+    <PackageReference Include="cloudscribe.Web.SiteMap.FromNavigation" Version="10.1.0" />
 
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />

--- a/src/cloudscribe.DateTimeUtils/cloudscribe.DateTimeUtils.csproj
+++ b/src/cloudscribe.DateTimeUtils/cloudscribe.DateTimeUtils.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Easy cross platform timezone conversion for .NET Core</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
 

--- a/src/cloudscribe.EFCore.PostgreSql.Conventions/cloudscribe.EFCore.PostgreSql.Conventions.csproj
+++ b/src/cloudscribe.EFCore.PostgreSql.Conventions/cloudscribe.EFCore.PostgreSql.Conventions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>PostgreSql Entity Framework Core conventions for snake case object names</Description>
     <Authors>Joe Audette</Authors>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/cloudscribe/cloudscribe</PackageProjectUrl>

--- a/src/cloudscribe.Email.Senders/cloudscribe.Email.Senders.csproj
+++ b/src/cloudscribe.Email.Senders/cloudscribe.Email.Senders.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Classes that provide a common interface for sending email with smtp or popular email apis including SendGrid, Mailgun, and ElasticEmail</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <Authors>Joe Audette</Authors>
     <TargetFramework>net10.0</TargetFramework>
     <PackageTags>smtp;email;SendGrid,Mailgun,ElasticEmail</PackageTags>

--- a/src/cloudscribe.FileManager.CoreIntegration/cloudscribe.FileManager.CoreIntegration.csproj
+++ b/src/cloudscribe.FileManager.CoreIntegration/cloudscribe.FileManager.CoreIntegration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>integration for cloudscribe Core and cloudscribe FileManager</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;filemanager</PackageTags>

--- a/src/cloudscribe.FileManager.Web/cloudscribe.FileManager.Web.csproj
+++ b/src/cloudscribe.FileManager.Web/cloudscribe.FileManager.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>media file management</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>

--- a/src/cloudscribe.IdentityServerIntegration.CompiledViews.Bootstrap5/cloudscribe.IdentityServerIntegration.CompiledViews.Bootstrap5.csproj
+++ b/src/cloudscribe.IdentityServerIntegration.CompiledViews.Bootstrap5/cloudscribe.IdentityServerIntegration.CompiledViews.Bootstrap5.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Bootstrap 5 pre-compiled views for cloudscribe.Core.IdentityServerIntegration</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <Authors>Joe Audette</Authors>

--- a/src/cloudscribe.MigrationHelper.mojoPortal/cloudscribe.MigrationHelper.mojoPortal.csproj
+++ b/src/cloudscribe.MigrationHelper.mojoPortal/cloudscribe.MigrationHelper.mojoPortal.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>An implementation of the cloudscribe IFallbackPasswordHashValidator that can migrate hashed passwords migrated in from mojoortal database users to cloudscribe users in the format Pwd|PasswordSalt. On first login the users password will be updated to the asp.net Identity hash format.</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe;mojoportal;migration</PackageTags>

--- a/src/cloudscribe.MultiTenancy/cloudscribe.MultiTenancy.csproj
+++ b/src/cloudscribe.MultiTenancy/cloudscribe.MultiTenancy.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>multi-tenancy for cloudscribe</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe</PackageTags>

--- a/src/cloudscribe.QueryTool.EFCore.Common/cloudscribe.QueryTool.EFCore.Common.csproj
+++ b/src/cloudscribe.QueryTool.EFCore.Common/cloudscribe.QueryTool.EFCore.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/cloudscribe.QueryTool.EFCore.MSSQL/cloudscribe.QueryTool.EFCore.MSSQL.csproj
+++ b/src/cloudscribe.QueryTool.EFCore.MSSQL/cloudscribe.QueryTool.EFCore.MSSQL.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/cloudscribe.QueryTool.EFCore.MySql/cloudscribe.QueryTool.EFCore.MySql.csproj
+++ b/src/cloudscribe.QueryTool.EFCore.MySql/cloudscribe.QueryTool.EFCore.MySql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/cloudscribe.QueryTool.EFCore.PostgreSql/cloudscribe.QueryTool.EFCore.PostgreSql.csproj
+++ b/src/cloudscribe.QueryTool.EFCore.PostgreSql/cloudscribe.QueryTool.EFCore.PostgreSql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/cloudscribe.QueryTool.EFCore.SQLite/cloudscribe.QueryTool.EFCore.SQLite.csproj
+++ b/src/cloudscribe.QueryTool.EFCore.SQLite/cloudscribe.QueryTool.EFCore.SQLite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/cloudscribe.QueryTool.Models/cloudscribe.QueryTool.Models.csproj
+++ b/src/cloudscribe.QueryTool.Models/cloudscribe.QueryTool.Models.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/cloudscribe.QueryTool.Services/cloudscribe.QueryTool.Services.csproj
+++ b/src/cloudscribe.QueryTool.Services/cloudscribe.QueryTool.Services.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/cloudscribe.QueryTool.Web/cloudscribe.QueryTool.Web.csproj
+++ b/src/cloudscribe.QueryTool.Web/cloudscribe.QueryTool.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/cloudscribe.Versioning/cloudscribe.Versioning.csproj
+++ b/src/cloudscribe.Versioning/cloudscribe.Versioning.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <Description>Common interfaces for providing library versions for display in a consuming application</Description>
     <Authors>Joe Audette</Authors>
     

--- a/src/cloudscribe.Web.Common/cloudscribe.Web.Common.csproj
+++ b/src/cloudscribe.Web.Common/cloudscribe.Web.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>cloudscribe common helpers for web applications</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>

--- a/src/cloudscribe.Web.StaticFiles/cloudscribe.Web.StaticFiles.csproj
+++ b/src/cloudscribe.Web.StaticFiles/cloudscribe.Web.StaticFiles.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>common static resources for web applications including ckeditor datepickers, and other js and css</Description>
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageTags>cloudscribe</PackageTags>

--- a/src/sourceDev.WebApp/sourceDev.WebApp.csproj
+++ b/src/sourceDev.WebApp/sourceDev.WebApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -66,11 +66,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="cloudscribe.Web.Localization" Version="10.0.*" />
+    <PackageReference Include="cloudscribe.Web.Localization" Version="10.1.*" />
     
     <!-- avoiding circularity in our build / increment process here... -->
     <!-- we're referencing Logger, but it has dependencies on other packages back in this repo -->
-    <!-- TEMPORARILY USING v8.* UNTIL LOGGER IS UPGRADED TO .NET 10 -->
+    <!-- TEMPORARILY USING v10.0.0 UNTIL LOGGER IS UPGRADED TO v10.1 -->
     <PackageReference Include="cloudscribe.Logging.Web" Version="10.0.0" />
     <PackageReference Include="cloudscribe.Logging.EFCore.MSSQL" Version="10.0.0" />
     <PackageReference Include="cloudscribe.Logging.EFCore.MySql" Version="10.0.0" />

--- a/update_version.ps1
+++ b/update_version.ps1
@@ -16,9 +16,9 @@
 $directory = "src"
 
 # Define the old & new versions
-$oldVersion = '8\.7'   # slash needed !
-$newVersion = "8.8.0"
-$newWildcardVersion = "8.8.*"
+$oldVersion = '10\.0'   # slash needed !
+$newVersion = "10.1.0"
+$newWildcardVersion = "10.1.*"
 	
 
 # Get all .csproj files in the directory and subdirectories


### PR DESCRIPTION
## Summary
Updates cloudscribe Core package versions from **10.0.0** to **10.1.0** across 40 .csproj files in preparation for the next minor release.

## Version Update Details
- **Previous Version**: 10.0.0
- **New Version**: 10.1.0
- **Update Script**: Modified `update_version.ps1` (10.0→10.1 version variables)
- **Files Modified**: 41 total (40 .csproj + 1 .ps1)

## Changes Made

### Core Projects (Identity, Models, Storage)
- `cloudscribe.Core.Identity.csproj` → 10.1.0
- `cloudscribe.Core.Models.csproj` → 10.1.0
- `cloudscribe.Core.Storage.EFCore.Common.csproj` → 10.1.0
- `cloudscribe.Core.Storage.EFCore.MSSQL.csproj` → 10.1.0
- `cloudscribe.Core.Storage.EFCore.MySql.csproj` → 10.1.0
- `cloudscribe.Core.Storage.EFCore.PostgreSql.csproj` → 10.1.0
- `cloudscribe.Core.Storage.EFCore.SQLite.csproj` → 10.1.0
- `cloudscribe.Core.Storage.NoDb.csproj` → 10.1.0
- `cloudscribe.Core.Web.csproj` → 10.1.0

### IdentityServer Integration Projects
- `cloudscribe.Core.IdentityServer.EFCore.Common.csproj` → 10.1.0
- `cloudscribe.Core.IdentityServer.EFCore.MSSQL.csproj` → 10.1.0
- `cloudscribe.Core.IdentityServer.EFCore.MySql.csproj` → 10.1.0
- `cloudscribe.Core.IdentityServer.EFCore.PostgreSql.csproj` → 10.1.0
- `cloudscribe.Core.IdentityServer.EFCore.SQLite.csproj` → 10.1.0
- `cloudscribe.Core.IdentityServer.NoDb.csproj` → 10.1.0
- `cloudscribe.Core.IdentityServerIntegration.csproj` → 10.1.0
- `cloudscribe.IdentityServerIntegration.CompiledViews.Bootstrap5.csproj` → 10.1.0

### LDAP Projects
- `cloudscribe.Core.Ldap.csproj` → 10.1.0
- `cloudscribe.Core.Ldap.Windows.csproj` → 10.1.0

### Multi-Tenancy & Utilities
- `cloudscribe.MultiTenancy.csproj` → 10.1.0
- `cloudscribe.DateTimeUtils.csproj` → 10.1.0
- `cloudscribe.Versioning.csproj` → 10.1.0
- `cloudscribe.EFCore.PostgreSql.Conventions.csproj` → 10.1.0

### Web & UI Projects
- `cloudscribe.Web.Common.csproj` → 10.1.0
- `cloudscribe.Web.StaticFiles.csproj` → 10.1.0
- `cloudscribe.Core.CompiledViews.Bootstrap5.csproj` → 10.1.0

### Feature Modules
- `cloudscribe.FileManager.CoreIntegration.csproj` → 10.1.0
- `cloudscribe.FileManager.Web.csproj` → 10.1.0
- `cloudscribe.QueryTool.EFCore.Common.csproj` → 10.1.0
- `cloudscribe.QueryTool.EFCore.MSSQL.csproj` → 10.1.0
- `cloudscribe.QueryTool.EFCore.MySql.csproj` → 10.1.0
- `cloudscribe.QueryTool.EFCore.PostgreSql.csproj` → 10.1.0
- `cloudscribe.QueryTool.EFCore.SQLite.csproj` → 10.1.0
- `cloudscribe.QueryTool.Models.csproj` → 10.1.0
- `cloudscribe.QueryTool.Services.csproj` → 10.1.0
- `cloudscribe.QueryTool.Web.csproj` → 10.1.0

### Migration & Utilities
- `cloudscribe.MigrationHelper.mojoPortal.csproj` → 10.1.0
- `cloudscribe.Common.Gdpr.csproj` → 10.1.0
- `cloudscribe.Email.Senders.csproj` → 10.1.0

### Development App
- `sourceDev.WebApp.csproj` → 10.1.0
  - **Note**: Logging package references remain at 10.0.0 (awaiting cloudscribe.Logging repo update)

## Build Status
✅ **Build Passed** - Warnings only, no errors

**Warnings Summary**:
- NU1510: Package pruning suggestions (non-critical)
- NU1608: Pomelo.EntityFrameworkCore.MySql dependency constraint (known, acceptable)
- NU1902/NU1903: Known security vulnerabilities in IdentityServer4 and AutoMapper (tracked separately)

## Testing Notes
- Standard build validation completed
- No functional code changes (version metadata only)
- All 43 projects compiled successfully

## Special Considerations
**cloudscribe.Logging Package References** (in `sourceDev.WebApp.csproj`):
- `cloudscribe.Logging.Web` → **Remains 10.0.0** (not 10.1.0)
- `cloudscribe.Logging.EFCore.MSSQL` → **Remains 10.0.0**
- `cloudscribe.Logging.EFCore.MySql` → **Remains 10.0.0**
- `cloudscribe.Logging.EFCore.PostgreSql` → **Remains 10.0.0**
- `cloudscribe.Logging.EFCore.SQLite` → **Remains 10.0.0**
- `cloudscribe.Logging.NoDb` → **Remains 10.0.0**

These will be updated to 10.1.0 after the `cloudscribe.Logging` repository (campaign step #6) completes its version update.

## Deployment Impact
- **Breaking Changes**: None
- **API Changes**: None
- **Database Changes**: None
- **Configuration Changes**: None

## Related PRs
- Part of the **10.0 → 10.1 version bump campaign** (5/14 repositories)
- Previous: cloudscribe.Syndication #33 ✅
- Next: cloudscribe.Logging

---
*Generated with assistance from Claude (Anthropic)*