### PR TITLE
#1284 Replace cloudscribe.HtmlAgilityPack with official HtmlAgilityPack

### DIFF
--- a/src/cloudscribe.Web.Common/Html/HtmlHelper.cs
+++ b/src/cloudscribe.Web.Common/Html/HtmlHelper.cs
@@ -1,4 +1,4 @@
-﻿using cloudscribe.HtmlAgilityPack;
+﻿using HtmlAgilityPack;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/cloudscribe.Web.Common/cloudscribe.Web.Common.csproj
+++ b/src/cloudscribe.Web.Common/cloudscribe.Web.Common.csproj
@@ -39,12 +39,11 @@
 
     <PackageReference Include="System.Text.Encodings.Web" Version="10.0.0" />
 
-    <PackageReference Include="cloudscribe.HtmlAgilityPack" Version="1.0.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 
     <!-- pulling up transitive deps to resolve security vulns -->
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     
   </ItemGroup>
 


### PR DESCRIPTION
- Replace cloudscribe.HtmlAgilityPack 1.0.1 with HtmlAgilityPack 1.11.71
- Update namespace in HtmlHelper.cs from cloudscribe.HtmlAgilityPack to HtmlAgilityPack
- Remove obsolete System.Net.Http 4.3.4 override (no longer needed)
- Eliminates NU1903 security vulnerability warning for System.Net.Http 4.3.0
- No code changes required - APIs are identical between packages
- Build verified successful with no errors

Fixes #1284